### PR TITLE
Feature league detection

### DIFF
--- a/src/controller/leagueclientcontroller.py
+++ b/src/controller/leagueclientcontroller.py
@@ -1,12 +1,77 @@
-from win32.win32gui import FindWindow, GetWindowRect, GetForegroundWindow, GetWindowText
+from win32.win32gui import EnumWindows, GetWindowRect, GetForegroundWindow, GetWindowText
+from win32.win32process import GetWindowThreadProcessId
 from constant import Monsoon
+
+import subprocess
+import re
 
 class LeagueClientController():
   def __init__(self):
-    self.window_name = "League of Legends"
+    self.process_name = "LeagueClientUx.exe"
+    self.window = None
 
-  def __find_window__(self):
-    return FindWindow(None, self.window_name)
+  def __on_enumerate_window__(self, window_handle, process_id):
+    """Callback for EnumWindows to get League client window.
+
+    Args:
+        hwnd (object): Window handle.
+        extra (object): Process id.
+
+    Returns:
+        bool: Condition to end EnumWindows
+    """
+    # Did we find the League client window associated with process id?
+    if process_id in GetWindowThreadProcessId(window_handle):
+      self.window = window_handle
+      # Return False to end enumeration early for EnumWindows caller
+      # http://timgolden.me.uk/pywin32-docs/win32gui__EnumWindows_meth.html
+      return False
+  
+  def __parse_process_id__(self, data: str):
+    """Parse process id from a data string using regular expression.
+
+    Args:
+        data (str): Raw data string output from process.
+
+    Returns:
+        int | None
+    """
+    match = re.search(r"\d+", data)
+    if match == None:
+      return None
+
+    return int(match.group())
+  
+
+  def __find_window__(self, is_memoized=True):
+    """Find the window associated with the League client process.
+
+    Args:
+        is_memoized (bool, optional): Use cached instance. Defaults to True.
+
+    Returns:
+        object | None: Window handle or None when no window is found.
+    """
+    data_string = str(subprocess.Popen(
+      f"wmic PROCESS WHERE name='{self.process_name}' GET processid",
+      shell=True,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE).communicate()[0]
+    )
+    process_id = self.__parse_process_id__(data_string)
+
+    if is_memoized and self.window != None and process_id:
+      return self.window
+
+    self.window = None
+    # Have to use try...except due to EnumWindows weird behavior when ending 
+    # enumeration early. u.u
+    try:
+      EnumWindows(self.__on_enumerate_window__, process_id)
+    except Exception:
+      pass
+
+    return self.window
 
   def is_active(self):
     """Test if the League client is active.
@@ -14,12 +79,12 @@ class LeagueClientController():
     Returns:
         bool: Existance of League client.
     """ 
-    if (self.__find_window__()):
+    if (self.__find_window__(is_memoized=False)):
       return True
     return False
   
   def is_foreground(self):
-    return self.window_name == GetWindowText(GetForegroundWindow())
+    return self.window == GetForegroundWindow()
 
   def is_overlayed(self):
     return Monsoon.TITLE.value == GetWindowText(GetForegroundWindow())

--- a/src/controller/leagueclientcontroller.py
+++ b/src/controller/leagueclientcontroller.py
@@ -63,13 +63,15 @@ class LeagueClientController():
     )
     process_id = self.__parse_process_id__(data_string)
 
-    self.window = None
     # Have to use try...except due to EnumWindows weird behavior when ending 
     # enumeration early. u.u
+    is_window_found = False
     try:
       EnumWindows(self.__on_enumerate_window__, process_id)
     except Exception:
-      pass
+      is_window_found = True
+    if not is_window_found:
+      self.window = None
 
     return self.window
   
@@ -84,8 +86,15 @@ class LeagueClientController():
     Returns:
         bool: Existance of League client.
     """ 
+    # Window does not exist yet
+    if not self.window:
+      return False
+    # Window was used but has been exited
+    if not self.find():
+      return False
     if (self.__find_window__()):
       return True
+
     return False
   
   def is_foreground(self):
@@ -98,9 +107,13 @@ class LeagueClientController():
     """Gets the window coordinates of the League client.
 
     Returns:
-        tuple: (left, top, right, bottom)
+        tuple | None: (left, top, right, bottom) or None when window does not
+        exist.
     """
     window_handle = self.__find_window__()
-    window_rect = GetWindowRect(window_handle)
+    try:
+      window_rect = GetWindowRect(window_handle)
+    except Exception:
+      return None
     
     return window_rect

--- a/src/controller/leagueclientcontroller.py
+++ b/src/controller/leagueclientcontroller.py
@@ -44,7 +44,7 @@ class LeagueClientController():
   
 
   def __find_window__(self, is_memoized=True):
-    """Find the window associated with the League client process.
+    """Find the window associated with the League client process. Mutative.
 
     Args:
         is_memoized (bool, optional): Use cached instance. Defaults to True.
@@ -52,6 +52,9 @@ class LeagueClientController():
     Returns:
         object | None: Window handle or None when no window is found.
     """
+    if is_memoized and self.window != None:
+      return self.window
+
     data_string = str(subprocess.Popen(
       f"wmic PROCESS WHERE name='{self.process_name}' GET processid",
       shell=True,
@@ -59,9 +62,6 @@ class LeagueClientController():
       stderr=subprocess.PIPE).communicate()[0]
     )
     process_id = self.__parse_process_id__(data_string)
-
-    if is_memoized and self.window != None and process_id:
-      return self.window
 
     self.window = None
     # Have to use try...except due to EnumWindows weird behavior when ending 
@@ -72,6 +72,11 @@ class LeagueClientController():
       pass
 
     return self.window
+  
+  def process(self):
+    """Process the controller to find the window for the League client.
+    """
+    self.__find_window__(is_memoized=False)
 
   def is_active(self):
     """Test if the League client is active.
@@ -79,7 +84,7 @@ class LeagueClientController():
     Returns:
         bool: Existance of League client.
     """ 
-    if (self.__find_window__(is_memoized=False)):
+    if (self.__find_window__()):
       return True
     return False
   

--- a/src/monsoon.py
+++ b/src/monsoon.py
@@ -1,17 +1,13 @@
 from constant import Embedded, Stylesheet
 from controller import EventDataController, LeagueClientController
-from service import TimerService
+from service import ExecutorService, TimerService
 from template import SystemTray
 from util import b64_to_qicon
 from view import MainView
 
 import asyncio
-import json
 import logging
-import willump
 from PySide6 import QtWidgets
-from threading import Thread
-from time import sleep
 
 def milliseconds_from_fps(fps: int) -> int:
   """Calculate milliseconds from the rate of frames per second.
@@ -24,47 +20,35 @@ def milliseconds_from_fps(fps: int) -> int:
   """
   return (1 / fps) * 1000
 
-async def data_callback(data, controller: EventDataController):
-  """Pass WebSocket event data to the event data controller.
+def create_app() -> QtWidgets.QApplication:
+  """Create our main Qt application with settings applied.
 
-  Args:
-      data (object): League client event data
-      controller (EventDataController): Controller for WebSocket event data
+  Returns:
+      QtWidgets.QApplication: Main application
   """
-  print(json.dumps(data, indent=4, sort_keys=True))
-  controller.events_queue.append(data)
-
-async def setup_client_connection(controller: EventDataController):
-  """Setup the League client connection and subscribe to WebSocket.
-
-  Args:
-      controller (EventDataController): Event data controller
-  """
-  global wllp
-  wllp = await willump.start()
-  
-  subscription = await wllp.subscribe(
-    "OnJsonApiEvent_lol-champ-select_v1_session",
-     default_handler=lambda data: data_callback(data, controller)
-  )
-
-async def main():
-  """Asynchronously run the main application.
-  """
-  logging.basicConfig(level=logging.DEBUG)
-
-  # Setup application
   app = QtWidgets.QApplication([])
   app.setStyleSheet(Stylesheet.value())
   app.setWindowIcon(b64_to_qicon(Embedded.icon()))
 
-  # Setup system tray icon
+  return app
+
+def create_tray() -> SystemTray:
+  """Create our system tray with actions.
+
+  Returns:
+      SystemTray: System tray
+  """
   tray = SystemTray()
   tray.show()
 
-  # Setup and pass controllers using dependency injection
-  event_data_controller = EventDataController()
-  client_controller = LeagueClientController()
+  return tray
+
+async def main(
+  client_controller: LeagueClientController,
+  event_data_controller: EventDataController,
+  executor: ExecutorService):
+  """Asynchronously run the main application.
+  """
   view = MainView(
     event_data_controller=event_data_controller,
     client_controller=client_controller
@@ -74,60 +58,30 @@ async def main():
   update_timer = TimerService(milliseconds_from_fps(20))
   update_timer.add_slot(view.refresh)
 
-  # Poll long-running operation for client process using another thread
-  def poll_task():
-    while True:
-      global stop_threads_flag
-      if stop_threads_flag == True:
-        break
-      sleep(5)
-      client_controller.process()
-
-  poll_process_thread = Thread(target=poll_task)
-  poll_process_thread.start()
-
-  async def exec_loop():
-    """ Execute the event loop that processes both Qt and asyncio loops.
-    """
-    global wllp
-    is_locked = False
-    is_wllp_running = False
-    while True:
-      if not is_locked:
-        if not client_controller.is_active():
-          is_locked = True
-          if wllp != None:
-            is_wllp_running = False
-            asyncio.ensure_future(wllp.close())
-
-      
-      if client_controller.is_active():
-        is_locked = False
-        if not is_wllp_running:
-          is_wllp_running = True
-
-          # Sleep for five seconds to ensure that the WebSocket subscription works. u.u
-          # This should be handled by `willump` but we have to bandaid fix this for now. :c
-          # Submit a pull request if a better alternative is found.
-          sleep(5)
-          asyncio.ensure_future(setup_client_connection(event_data_controller))
-
-      app.processEvents()
-      await asyncio.sleep(0)
-
-  await exec_loop()
-
+  await executor.exec_event_loop()
 
 if __name__ == "__main__":
-  global wllp
-  global stop_threads_flag
-  wllp = None
-  stop_threads_flag = False
+  logging.basicConfig(level=logging.DEBUG)
   loop = asyncio.get_event_loop()
-
+  app = create_app()
+  tray = create_tray()
+  client_controller = LeagueClientController()
+  event_data_controller = EventDataController()
+  executor = ExecutorService(
+    app=app, 
+    client_controller=client_controller,
+    event_data_controller=event_data_controller,
+    ui_event_loop=loop
+    )
   try:
-    loop.run_until_complete(main())
+    loop.run_until_complete(
+      main(
+        client_controller=client_controller,
+        event_data_controller=event_data_controller,
+        executor=executor
+      )
+    )
   except KeyboardInterrupt:
-    stop_threads_flag = True
-    loop.run_until_complete(wllp.close())
+    executor.is_program_exiting = True
+    loop.run_until_complete(executor._kill_willump())
     print()

--- a/src/service/__init__.py
+++ b/src/service/__init__.py
@@ -1,1 +1,2 @@
+from service.executorservice import ExecutorService
 from service.timerservice import TimerService

--- a/src/service/executorservice.py
+++ b/src/service/executorservice.py
@@ -1,0 +1,110 @@
+from controller import EventDataController, LeagueClientController
+
+import asyncio
+import logging
+import json
+from PySide6 import QtWidgets
+from threading import Thread
+from time import sleep
+import willump
+
+
+class ExecutorService():
+  """Represents the executor that manages the state of the program.
+  """
+  def __init__(
+    self, 
+    app: QtWidgets.QApplication, 
+    client_controller: LeagueClientController,
+    event_data_controller: EventDataController,
+    ui_event_loop: asyncio.AbstractEventLoop):
+    self.app = app
+    self.client_controller = client_controller
+    self.event_data_controller = event_data_controller
+    self.is_program_exiting = False
+    self.is_willump_active = False
+    self.subscription = None
+    self.ui_event_loop = ui_event_loop
+    self.wllp = None
+
+
+  async def _on_websocket_event(self, data):
+    """Pass WebSocket event data to the event data controller. Mutative.
+
+    Args:
+        data (object): League client event data
+    """
+    print(json.dumps(data, indent=4, sort_keys=True))
+    self.event_data_controller.events_queue.append(data)
+  
+  async def _kill_willump(self):
+    """Attempt to close willump asynchronosuly. Mutative.
+    """
+    try:
+      await self.wllp.close()
+    except Exception:
+      pass
+    finally:
+      self.wllp = None
+      self.is_willump_active = False
+
+  async def _exec_willump(self):
+    """Execute willump asynchronously with WebSocket subscription. Mutative.
+    """
+    self.wllp = await willump.start()
+    # Sleep for five seconds to ensure that the WebSocket subscription works. u.u
+    # This should be handled by `willump` but we have to bandaid fix this for now. :c
+    # Submit a pull request if a better alternative is found.
+    sleep(5)
+    self.subscription = await self.wllp.subscribe(
+      "OnJsonApiEvent_lol-champ-select_v1_session",
+        default_handler=self._on_websocket_event
+    )
+
+  def _process(self):
+    """Process the state of willump and create appropriate futures in event loop.
+    """
+    asyncio.set_event_loop(loop=self.ui_event_loop)
+    if self.client_controller.is_active():
+      if self.is_willump_active:
+        logging.debug("hugging willump... :3")
+        return
+
+      logging.debug("requesting willump... o.o")
+      self.is_willump_active = True
+      asyncio.ensure_future(self._exec_willump())
+      return
+
+    # Probable that the League client process is dead if we have reached this point.
+    logging.debug("bye bye willump... u.u")
+    asyncio.ensure_future(self._kill_willump())
+
+
+  def _exec_client_loop_task(self):
+    """Long-running client processing loop that will run in a seperate thread.
+    """
+    while True:
+      if self.is_program_exiting:
+        break
+      sleep(5)
+      self.client_controller.process()
+      self._process()
+
+  async def _exec_ui_loop(self):
+    """Execute the event loop responsible for Qt render and WebSocket events.
+    """
+    while True:
+      self.app.processEvents()
+      await asyncio.sleep(0, loop=self.ui_event_loop)
+  
+  def _start_thread(self, task):
+    """Execute a thread with a given task.
+    """
+    thread = Thread(target=task)
+    thread.start()
+  
+  async def exec_event_loop(self):
+    """Execute the main orchestrating event loop.
+    """
+    self._start_thread(self._exec_client_loop_task)
+    await self._exec_ui_loop()

--- a/src/template/systemtray.py
+++ b/src/template/systemtray.py
@@ -1,4 +1,4 @@
-import sys
+import os
 import webbrowser
 from PySide6 import QtWidgets
 from constant import Embedded, Monsoon
@@ -40,4 +40,4 @@ class SystemTray(QtWidgets.QSystemTrayIcon):
     webbrowser.open(url)
   
   def __exit_application__(self):
-    sys.exit()
+    os._exit(0)

--- a/src/view/mainview.py
+++ b/src/view/mainview.py
@@ -2,7 +2,7 @@ from PySide6 import QtWidgets, QtCore
 from constant import Embedded, Monsoon
 from controller import EventDataController, LeagueClientController
 from util import LayoutFactory, b64_to_qpixmap
-import sys
+import os
 import traceback
 
 class MainView(QtWidgets.QMainWindow):
@@ -138,5 +138,5 @@ class MainView(QtWidgets.QMainWindow):
         msg.setInformativeText(traceback.format_exc())
         msg.setWindowTitle(":bee_sad:")
         msg.exec_()
-        sys.exit()
+        os._exit(-1)
 

--- a/src/view/mainview.py
+++ b/src/view/mainview.py
@@ -6,13 +6,20 @@ import sys
 import traceback
 
 class MainView(QtWidgets.QMainWindow):
-  def __init__(self, event_data_controller: EventDataController):
+  def __init__(
+    self,
+    client_controller: LeagueClientController,
+    event_data_controller: EventDataController
+    ):
+
     super().__init__()
     self.setObjectName("mainView")
 
-    # Set instance variables
-    self.client_controller = LeagueClientController()
+    # Use dependency-injected controllers
+    self.client_controller = client_controller
     self.event_data_controller = event_data_controller
+
+    # Set instance variables
     (self.hbox, self.hbox_layout) = LayoutFactory.create_horizontal()
     (self.left_vbox, self.left_vbox_layout) = LayoutFactory.create_vertical()
     (self.left_sub_hbox, self.left_sub_hbox_layout) = LayoutFactory.create_horizontal()

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -9,3 +9,7 @@ class TestController():
     def test_is_active_returns_true(self):
       controller = LeagueClientController()
       assert controller.is_active() == True
+    
+    def test_find_returns_any(self):
+      controller = LeagueClientController()
+      assert controller.find() != None


### PR DESCRIPTION
### Changes
- Now finds the window by associated process, "LeagueClientUx.exe" (old way required finding a window of title name "League of Legends"). Solves #3.
- Add associated unit test

There were significant pain points with trying to implement the new detection strategy in the old event loop. The `main()` function was refactored to make the transition more easy peasy. :3
- Add `ExecutorService` to manage needed event loops and long-running thread
- Decouple and refactor event loop functions into `ExecutorService`